### PR TITLE
feat: 커뮤니티 모임 리스트 페이지 구현

### DIFF
--- a/app/community/groups/page.tsx
+++ b/app/community/groups/page.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import React, { useState, useMemo } from "react";
+import { CommunityHeader } from "@/components/ui/CommunityHeader";
+import { CommunityFilters } from "@/components/ui/CommunityFilters";
+import { PostCard } from "@/components/ui/PostCard";
+import { FloatingActionButton } from "@/components/ui/FloatingActionButton";
+import { mockPosts } from "@/data/mockPosts";
+import { Post, CategoryTab, SortOption, PostState } from "@/types/community";
+
+export default function GroupsPage() {
+  const [activeCategory, setActiveCategory] =
+    useState<CategoryTab["key"]>("소분 모임");
+  const [isInterestOnly, setIsInterestOnly] = useState(false);
+  const [sortBy, setSortBy] = useState<SortOption["value"]>("등록순");
+  const [postState] = useState<PostState>("loaded");
+
+  // 필터링된 포스트 목록
+  const filteredPosts = useMemo(() => {
+    let filtered = [...mockPosts];
+
+    // 카테고리 필터링
+    if (activeCategory !== "전체") {
+      filtered = filtered.filter((post) => {
+        if (activeCategory === "안전 수리") {
+          return (
+            post.title.includes("CCTV") ||
+            post.title.includes("가로등") ||
+            post.title.includes("수리")
+          );
+        }
+        if (activeCategory === "소분 모임") {
+          return post.badge?.label === "소분 모임";
+        }
+        if (activeCategory === "취미·기타") {
+          return (
+            !post.badge ||
+            (post.badge.label !== "소분 모임" &&
+              !post.title.includes("CCTV") &&
+              !post.title.includes("가로등"))
+          );
+        }
+        return true;
+      });
+    }
+
+    // 관심글 필터링 (임시로 좋아요 15개 이상으로 필터)
+    if (isInterestOnly) {
+      filtered = filtered.filter((post) => post.stats.likes >= 15);
+    }
+
+    // 정렬
+    if (sortBy === "최신순") {
+      filtered = filtered.sort((a, b) => {
+        const getTimeValue = (timeStr: string) => {
+          if (timeStr.includes("시간전")) return parseInt(timeStr) / 24;
+          if (timeStr.includes("일전")) return parseInt(timeStr);
+          if (timeStr.includes("주전")) return parseInt(timeStr) * 7;
+          return 0;
+        };
+        return getTimeValue(a.createdAgo) - getTimeValue(b.createdAgo);
+      });
+    }
+
+    return filtered;
+  }, [activeCategory, isInterestOnly, sortBy]);
+
+  const handlePostClick = (post: Post) => {
+    console.log("게시글 클릭:", post.title);
+    // TODO: 게시글 상세 페이지로 이동
+  };
+
+  const handleMenuAction = (
+    action: "create_group" | "create_post",
+    post: Post,
+  ) => {
+    console.log(`${action} 선택:`, post.title);
+    // TODO: 모임 개설 또는 일반 게시글 작성 페이지로 이동
+  };
+
+  const handleNotificationClick = () => {
+    console.log("알림 클릭");
+    // TODO: 알림 페이지로 이동
+  };
+
+  if (postState === "loading") {
+    return (
+      <div className="flex flex-col min-h-screen bg-[#F8FAFC]">
+        <CommunityHeader title="모임" />
+        <div className="flex-1 p-4">
+          <div className="space-y-4">
+            {[...Array(4)].map((_, i) => (
+              <div key={i} className="bg-white rounded-2xl p-4 animate-pulse">
+                <div className="flex justify-between mb-3">
+                  <div className="h-4 bg-gray-200 rounded w-24"></div>
+                  <div className="h-6 bg-gray-200 rounded w-16"></div>
+                </div>
+                <div className="h-5 bg-gray-200 rounded w-3/4 mb-2"></div>
+                <div className="h-4 bg-gray-200 rounded w-full mb-1"></div>
+                <div className="h-4 bg-gray-200 rounded w-2/3 mb-4"></div>
+                <div className="flex justify-between">
+                  <div className="h-4 bg-gray-200 rounded w-20"></div>
+                  <div className="flex gap-3">
+                    <div className="h-4 bg-gray-200 rounded w-8"></div>
+                    <div className="h-4 bg-gray-200 rounded w-8"></div>
+                    <div className="h-4 bg-gray-200 rounded w-8"></div>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (postState === "empty") {
+    return (
+      <div className="flex flex-col min-h-screen bg-[#F8FAFC]">
+        <CommunityHeader
+          title="모임"
+          onNotificationClick={handleNotificationClick}
+        />
+        <CommunityFilters
+          activeCategory={activeCategory}
+          isInterestOnly={isInterestOnly}
+          sortBy={sortBy}
+          onCategoryChange={setActiveCategory}
+          onInterestToggle={() => setIsInterestOnly(!isInterestOnly)}
+          onSortChange={setSortBy}
+        />
+        <div className="flex-1 flex flex-col items-center justify-center p-8 text-center">
+          <div className="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mb-4">
+            <span className="text-2xl">📋</span>
+          </div>
+          <h3 className="text-lg font-semibold text-gray-900 mb-2">
+            아직 등록된 모임이 없어요
+          </h3>
+          <p className="text-gray-500 mb-6">
+            우리 동네 첫 번째 모임을 만들어보세요!
+          </p>
+          <button className="px-6 py-3 bg-[#2ECC71] text-white font-semibold rounded-full hover:bg-[#27AE60] transition-colors">
+            모임 개설하기
+          </button>
+        </div>
+        <FloatingActionButton />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col min-h-screen bg-[#F8FAFC]">
+      {/* 헤더 */}
+      <CommunityHeader
+        title="모임"
+        onNotificationClick={handleNotificationClick}
+      />
+
+      {/* 필터 */}
+      <CommunityFilters
+        activeCategory={activeCategory}
+        isInterestOnly={isInterestOnly}
+        sortBy={sortBy}
+        onCategoryChange={setActiveCategory}
+        onInterestToggle={() => setIsInterestOnly(!isInterestOnly)}
+        onSortChange={setSortBy}
+      />
+
+      {/* 피드 */}
+      <div id="main-content" className="flex-1 overflow-y-auto">
+        <div className="p-4 space-y-4 pb-24">
+          {filteredPosts.map((post) => (
+            <PostCard
+              key={post.id}
+              post={post}
+              onClick={handlePostClick}
+              onMenuAction={handleMenuAction}
+            />
+          ))}
+
+          {filteredPosts.length === 0 && (
+            <div className="text-center py-12">
+              <p className="text-gray-500">해당 조건의 모임이 없습니다.</p>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* 플로팅 액션 버튼 */}
+      <FloatingActionButton />
+    </div>
+  );
+}

--- a/app/community/groups/page.tsx
+++ b/app/community/groups/page.tsx
@@ -47,27 +47,7 @@ export default function GroupsPage() {
 
     // 카테고리 필터링
     if (activeCategory !== "전체") {
-      filtered = filtered.filter((post) => {
-        if (activeCategory === "안전 수리") {
-          return (
-            post.title.includes("CCTV") ||
-            post.title.includes("가로등") ||
-            post.title.includes("수리")
-          );
-        }
-        if (activeCategory === "소분 모임") {
-          return post.badge?.label === "소분 모임";
-        }
-        if (activeCategory === "취미·기타") {
-          return (
-            !post.badge ||
-            (post.badge.label !== "소분 모임" &&
-              !post.title.includes("CCTV") &&
-              !post.title.includes("가로등"))
-          );
-        }
-        return true;
-      });
+      filtered = filtered.filter((post) => post.category === activeCategory);
     }
 
     // 관심글 필터링 (임시로 좋아요 15개 이상으로 필터)
@@ -94,14 +74,6 @@ export default function GroupsPage() {
   const handlePostClick = (post: Post) => {
     console.log("게시글 클릭:", post.title);
     // TODO: 게시글 상세 페이지로 이동
-  };
-
-  const handleMenuAction = (
-    action: "create_group" | "create_post",
-    post: Post,
-  ) => {
-    console.log(`${action} 선택:`, post.title);
-    // TODO: 모임 개설 또는 일반 게시글 작성 페이지로 이동
   };
 
   const handleNotificationClick = () => {
@@ -196,12 +168,7 @@ export default function GroupsPage() {
       <div id="main-content" className="flex-1 overflow-y-auto">
         <div className="p-4 space-y-4 pb-24">
           {filteredPosts.map((post) => (
-            <PostCard
-              key={post.id}
-              post={post}
-              onClick={handlePostClick}
-              onMenuAction={handleMenuAction}
-            />
+            <PostCard key={post.id} post={post} onClick={handlePostClick} />
           ))}
 
           {filteredPosts.length === 0 && (

--- a/app/community/groups/page.tsx
+++ b/app/community/groups/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { CommunityHeader } from "@/components/ui/CommunityHeader";
 import { CommunityFilters } from "@/components/ui/CommunityFilters";
 import { PostCard } from "@/components/ui/PostCard";
@@ -9,11 +10,36 @@ import { mockPosts } from "@/data/mockPosts";
 import { Post, CategoryTab, SortOption, PostState } from "@/types/community";
 
 export default function GroupsPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
   const [activeCategory, setActiveCategory] =
     useState<CategoryTab["key"]>("소분 모임");
   const [isInterestOnly, setIsInterestOnly] = useState(false);
   const [sortBy, setSortBy] = useState<SortOption["value"]>("등록순");
   const [postState] = useState<PostState>("loaded");
+
+  // URL 쿼리에서 정렬 상태 초기화
+  useEffect(() => {
+    const sortParam = searchParams.get("sort");
+    if (sortParam === "recent") {
+      setSortBy("최신순");
+    } else {
+      setSortBy("등록순");
+    }
+  }, [searchParams]);
+
+  // 정렬 변경 시 URL 업데이트
+  const handleSortChange = (newSort: SortOption["value"]) => {
+    setSortBy(newSort);
+    const params = new URLSearchParams(searchParams);
+    if (newSort === "최신순") {
+      params.set("sort", "recent");
+    } else {
+      params.set("sort", "created");
+    }
+    router.replace(`/community/groups?${params.toString()}`);
+  };
 
   // 필터링된 포스트 목록
   const filteredPosts = useMemo(() => {
@@ -127,7 +153,7 @@ export default function GroupsPage() {
           sortBy={sortBy}
           onCategoryChange={setActiveCategory}
           onInterestToggle={() => setIsInterestOnly(!isInterestOnly)}
-          onSortChange={setSortBy}
+          onSortChange={handleSortChange}
         />
         <div className="flex-1 flex flex-col items-center justify-center p-8 text-center">
           <div className="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mb-4">
@@ -163,7 +189,7 @@ export default function GroupsPage() {
         sortBy={sortBy}
         onCategoryChange={setActiveCategory}
         onInterestToggle={() => setIsInterestOnly(!isInterestOnly)}
-        onSortChange={setSortBy}
+        onSortChange={handleSortChange}
       />
 
       {/* 피드 */}

--- a/components/ui/CommunityFilters.tsx
+++ b/components/ui/CommunityFilters.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useState } from "react";
-import { Heart, ChevronDown } from "lucide-react";
+import { Heart } from "lucide-react";
 import { cn } from "@/utils/cn";
 import { CategoryTab, SortOption } from "@/types/community";
 
@@ -36,11 +35,24 @@ export function CommunityFilters({
   onSortChange,
   className,
 }: CommunityFiltersProps) {
-  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-
-  const handleSortChange = (value: SortOption["value"]) => {
-    onSortChange(value);
-    setIsDropdownOpen(false);
+  const handleSortKeyDown = (
+    e: React.KeyboardEvent,
+    value: SortOption["value"],
+  ) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onSortChange(value);
+    } else if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
+      e.preventDefault();
+      const currentIndex = sortOptions.findIndex(
+        (option) => option.value === sortBy,
+      );
+      const nextIndex =
+        e.key === "ArrowRight"
+          ? (currentIndex + 1) % sortOptions.length
+          : (currentIndex - 1 + sortOptions.length) % sortOptions.length;
+      onSortChange(sortOptions[nextIndex].value);
+    }
   };
 
   return (
@@ -67,14 +79,14 @@ export function CommunityFilters({
       </div>
 
       {/* 보조 필터 */}
-      <div className="flex items-center justify-between px-4 py-3 border-t border-gray-50">
+      <div className="flex items-center justify-between px-4 py-2 border-t border-gray-50">
         {/* 관심글 토글 */}
         <button
           onClick={onInterestToggle}
           className={cn(
             "flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm font-medium transition-all duration-200",
             isInterestOnly
-              ? "bg-[#2ECC71]/10 text-[#2ECC71]"
+              ? "bg-[#0f5fda]/10 text-[#0f5fda]"
               : "text-gray-600 hover:text-gray-900 hover:bg-gray-50",
           )}
           aria-label="관심글만 보기"
@@ -86,48 +98,36 @@ export function CommunityFilters({
           <span>관심글</span>
         </button>
 
-        {/* 정렬 드롭다운 */}
-        <div className="relative">
-          <button
-            onClick={() => setIsDropdownOpen(!isDropdownOpen)}
-            className="flex items-center gap-1 px-3 py-1.5 text-sm text-gray-600 hover:text-gray-900 hover:bg-gray-50 rounded-lg transition-colors"
-            aria-label="정렬 옵션 선택"
-            aria-expanded={isDropdownOpen}
-          >
-            <span>{sortBy}</span>
-            <ChevronDown
-              size={14}
-              className={cn(
-                "transition-transform duration-200",
-                isDropdownOpen ? "rotate-180" : "",
+        {/* 정렬 세그먼트 토글 */}
+        <div
+          className="flex items-center gap-5"
+          role="tablist"
+          aria-label="정렬 옵션"
+        >
+          {sortOptions.map((option) => (
+            <button
+              key={option.value}
+              onClick={() => onSortChange(option.value)}
+              onKeyDown={(e) => handleSortKeyDown(e, option.value)}
+              className="inline-flex items-center gap-2 text-sm transition-colors duration-200"
+              role="tab"
+              aria-selected={sortBy === option.value}
+              tabIndex={sortBy === option.value ? 0 : -1}
+            >
+              {sortBy === option.value && (
+                <div className="w-1.5 h-1.5 rounded-full bg-[#0f5fda]" />
               )}
-            />
-          </button>
-
-          {isDropdownOpen && (
-            <>
-              <div
-                className="fixed inset-0 z-10"
-                onClick={() => setIsDropdownOpen(false)}
-              />
-              <div className="absolute right-0 top-full mt-1 bg-white border border-gray-200 rounded-lg shadow-md py-1 z-20 min-w-[100px]">
-                {sortOptions.map((option) => (
-                  <button
-                    key={option.value}
-                    onClick={() => handleSortChange(option.value)}
-                    className={cn(
-                      "w-full px-3 py-2 text-sm text-left hover:bg-gray-50 transition-colors",
-                      sortBy === option.value
-                        ? "text-[#2ECC71] font-medium"
-                        : "text-gray-700",
-                    )}
-                  >
-                    {option.label}
-                  </button>
-                ))}
-              </div>
-            </>
-          )}
+              <span
+                className={cn(
+                  sortBy === option.value
+                    ? "text-[#0f5fda] font-semibold"
+                    : "text-[#6B7280]",
+                )}
+              >
+                {option.label}
+              </span>
+            </button>
+          ))}
         </div>
       </div>
     </div>

--- a/components/ui/CommunityFilters.tsx
+++ b/components/ui/CommunityFilters.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useState } from "react";
+import { Heart, ChevronDown } from "lucide-react";
+import { cn } from "@/utils/cn";
+import { CategoryTab, SortOption } from "@/types/community";
+
+interface CommunityFiltersProps {
+  activeCategory: CategoryTab["key"];
+  isInterestOnly: boolean;
+  sortBy: SortOption["value"];
+  onCategoryChange: (category: CategoryTab["key"]) => void;
+  onInterestToggle: () => void;
+  onSortChange: (sort: SortOption["value"]) => void;
+  className?: string;
+}
+
+const categoryTabs: CategoryTab[] = [
+  { id: "all", label: "전체", key: "전체" },
+  { id: "safety", label: "안전 수리", key: "안전 수리" },
+  { id: "small_group", label: "소분 모임", key: "소분 모임" },
+  { id: "hobby", label: "취미·기타", key: "취미·기타" },
+];
+
+const sortOptions: SortOption[] = [
+  { value: "등록순", label: "등록순" },
+  { value: "최신순", label: "최신순" },
+];
+
+export function CommunityFilters({
+  activeCategory,
+  isInterestOnly,
+  sortBy,
+  onCategoryChange,
+  onInterestToggle,
+  onSortChange,
+  className,
+}: CommunityFiltersProps) {
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+
+  const handleSortChange = (value: SortOption["value"]) => {
+    onSortChange(value);
+    setIsDropdownOpen(false);
+  };
+
+  return (
+    <div className={cn("bg-white border-b border-gray-100", className)}>
+      {/* 카테고리 탭 */}
+      <div className="px-4 py-3">
+        <div className="flex justify-center gap-2 overflow-x-auto scrollbar-hide">
+          {categoryTabs.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => onCategoryChange(tab.key)}
+              className={cn(
+                "flex-shrink-0 px-4 py-2 rounded-full text-sm font-medium transition-all duration-200",
+                activeCategory === tab.key
+                  ? "bg-[#2ECC71]/10 text-[#2ECC71] font-semibold"
+                  : "text-gray-600 hover:text-gray-900 hover:bg-gray-50",
+              )}
+              aria-label={`${tab.label} 카테고리 선택`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* 보조 필터 */}
+      <div className="flex items-center justify-between px-4 py-3 border-t border-gray-50">
+        {/* 관심글 토글 */}
+        <button
+          onClick={onInterestToggle}
+          className={cn(
+            "flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm font-medium transition-all duration-200",
+            isInterestOnly
+              ? "bg-[#2ECC71]/10 text-[#2ECC71]"
+              : "text-gray-600 hover:text-gray-900 hover:bg-gray-50",
+          )}
+          aria-label="관심글만 보기"
+        >
+          <Heart
+            size={16}
+            className={cn(isInterestOnly ? "fill-current" : "stroke-current")}
+          />
+          <span>관심글</span>
+        </button>
+
+        {/* 정렬 드롭다운 */}
+        <div className="relative">
+          <button
+            onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+            className="flex items-center gap-1 px-3 py-1.5 text-sm text-gray-600 hover:text-gray-900 hover:bg-gray-50 rounded-lg transition-colors"
+            aria-label="정렬 옵션 선택"
+            aria-expanded={isDropdownOpen}
+          >
+            <span>{sortBy}</span>
+            <ChevronDown
+              size={14}
+              className={cn(
+                "transition-transform duration-200",
+                isDropdownOpen ? "rotate-180" : "",
+              )}
+            />
+          </button>
+
+          {isDropdownOpen && (
+            <>
+              <div
+                className="fixed inset-0 z-10"
+                onClick={() => setIsDropdownOpen(false)}
+              />
+              <div className="absolute right-0 top-full mt-1 bg-white border border-gray-200 rounded-lg shadow-md py-1 z-20 min-w-[100px]">
+                {sortOptions.map((option) => (
+                  <button
+                    key={option.value}
+                    onClick={() => handleSortChange(option.value)}
+                    className={cn(
+                      "w-full px-3 py-2 text-sm text-left hover:bg-gray-50 transition-colors",
+                      sortBy === option.value
+                        ? "text-[#2ECC71] font-medium"
+                        : "text-gray-700",
+                    )}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/ui/CommunityFilters.tsx
+++ b/components/ui/CommunityFilters.tsx
@@ -19,6 +19,7 @@ const categoryTabs: CategoryTab[] = [
   { id: "safety", label: "안전 수리", key: "안전 수리" },
   { id: "small_group", label: "소분 모임", key: "소분 모임" },
   { id: "hobby", label: "취미·기타", key: "취미·기타" },
+  { id: "general", label: "일반", key: "일반" },
 ];
 
 const sortOptions: SortOption[] = [
@@ -58,23 +59,25 @@ export function CommunityFilters({
   return (
     <div className={cn("bg-white border-b border-gray-100", className)}>
       {/* 카테고리 탭 */}
-      <div className="px-4 py-3">
-        <div className="flex justify-center gap-2 overflow-x-auto scrollbar-hide">
-          {categoryTabs.map((tab) => (
-            <button
-              key={tab.id}
-              onClick={() => onCategoryChange(tab.key)}
-              className={cn(
-                "flex-shrink-0 px-4 py-2 rounded-full text-sm font-medium transition-all duration-200",
-                activeCategory === tab.key
-                  ? "bg-[#2ECC71]/10 text-[#2ECC71] font-semibold"
-                  : "text-gray-600 hover:text-gray-900 hover:bg-gray-50",
-              )}
-              aria-label={`${tab.label} 카테고리 선택`}
-            >
-              {tab.label}
-            </button>
-          ))}
+      <div className="py-3">
+        <div className="overflow-x-auto scrollbar-hide pl-4">
+          <div className="flex gap-3 pr-4" style={{ width: "max-content" }}>
+            {categoryTabs.map((tab) => (
+              <button
+                key={tab.id}
+                onClick={() => onCategoryChange(tab.key)}
+                className={cn(
+                  "flex-shrink-0 whitespace-nowrap px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200",
+                  activeCategory === tab.key
+                    ? "bg-[#0f5fda]/10 text-[#0f5fda] font-semibold"
+                    : "text-gray-600 hover:text-gray-900 hover:bg-gray-50",
+                )}
+                aria-label={`${tab.label} 카테고리 선택`}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
         </div>
       </div>
 

--- a/components/ui/CommunityHeader.tsx
+++ b/components/ui/CommunityHeader.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { ChevronLeft, Bell } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { cn } from "@/utils/cn";
+
+interface CommunityHeaderProps {
+  title: string;
+  className?: string;
+  onBackClick?: () => void;
+  onNotificationClick?: () => void;
+}
+
+export function CommunityHeader({
+  title,
+  className,
+  onBackClick,
+  onNotificationClick,
+}: CommunityHeaderProps) {
+  const router = useRouter();
+
+  const handleBackClick = () => {
+    if (onBackClick) {
+      onBackClick();
+    } else {
+      router.back();
+    }
+  };
+
+  const handleNotificationClick = () => {
+    if (onNotificationClick) {
+      onNotificationClick();
+    }
+  };
+
+  return (
+    <>
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 z-50 bg-[#2ECC71] text-white px-4 py-2 rounded-md font-medium"
+      >
+        메인 콘텐츠로 건너뛰기
+      </a>
+      <header
+        className={cn(
+          "sticky top-0 z-40 w-full bg-white/80 backdrop-blur-sm border-b border-gray-100",
+          className,
+        )}
+      >
+        <div className="flex items-center justify-between px-4 py-3 h-14">
+          <button
+            onClick={handleBackClick}
+            className="flex items-center justify-center w-10 h-10 -ml-2 rounded-full hover:bg-gray-50 transition-colors"
+            aria-label="뒤로가기"
+          >
+            <ChevronLeft size={24} className="text-gray-700" />
+          </button>
+
+          <h1 className="flex-1 text-center text-lg font-semibold text-gray-900 tracking-tight">
+            {title}
+          </h1>
+
+          <button
+            onClick={handleNotificationClick}
+            className="flex items-center justify-center w-10 h-10 -mr-2 rounded-full hover:bg-gray-50 transition-colors"
+            aria-label="알림"
+          >
+            <Bell size={20} className="text-gray-700" />
+          </button>
+        </div>
+      </header>
+    </>
+  );
+}

--- a/components/ui/FloatingActionButton.tsx
+++ b/components/ui/FloatingActionButton.tsx
@@ -2,47 +2,116 @@
 
 import { Pen } from "lucide-react";
 import { useRouter } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
 import { cn } from "@/utils/cn";
 
 interface FloatingActionButtonProps {
-  onClick?: () => void;
-  href?: string;
   className?: string;
-  "aria-label"?: string;
 }
 
-export function FloatingActionButton({
-  onClick,
-  href = "/community/groups/create",
-  className,
-  "aria-label": ariaLabel = "글쓰기",
-}: FloatingActionButtonProps) {
-  const router = useRouter();
+const menuItems = [
+  { label: "모임 개설", href: "/community/new-group" },
+  { label: "일반 게시글", href: "/community/new-post" },
+];
 
-  const handleClick = () => {
-    if (onClick) {
-      onClick();
-    } else if (href) {
-      router.push(href);
+export function FloatingActionButton({ className }: FloatingActionButtonProps) {
+  const router = useRouter();
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  // 외부 클릭 시 메뉴 닫기
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        menuRef.current &&
+        buttonRef.current &&
+        !menuRef.current.contains(event.target as Node) &&
+        !buttonRef.current.contains(event.target as Node)
+      ) {
+        setIsMenuOpen(false);
+      }
+    };
+
+    const handleEscapeKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsMenuOpen(false);
+        buttonRef.current?.focus();
+      }
+    };
+
+    if (isMenuOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+      document.addEventListener("keydown", handleEscapeKey);
     }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleEscapeKey);
+    };
+  }, [isMenuOpen]);
+
+  const handleButtonClick = () => {
+    setIsMenuOpen(!isMenuOpen);
+  };
+
+  const handleMenuItemClick = (href: string) => {
+    setIsMenuOpen(false);
+    router.push(href);
   };
 
   return (
-    <button
-      onClick={handleClick}
-      className={cn(
-        "absolute bottom-20 right-4 z-30",
-        "flex items-center justify-center w-14 h-14",
-        "bg-[#2ECC71] hover:bg-[#27AE60] active:bg-[#229954]",
-        "text-white rounded-full shadow-lg hover:shadow-xl",
-        "transition-all duration-200 ease-out",
-        "transform hover:scale-105 active:scale-95",
-        "focus:outline-none focus:ring-2 focus:ring-[#2ECC71] focus:ring-offset-2 focus:ring-offset-white",
-        className,
+    <>
+      {/* FAB 버튼 */}
+      <button
+        ref={buttonRef}
+        onClick={handleButtonClick}
+        className={cn(
+          "absolute bottom-20 right-4 z-30",
+          "flex items-center justify-center w-14 h-14",
+          "bg-gray-100 hover:bg-gray-200 active:bg-gray-300",
+          "text-gray-700 rounded-full shadow-lg hover:shadow-xl",
+          "transition-all duration-200 ease-out",
+          "transform hover:scale-105 active:scale-95",
+          "focus:outline-none focus:ring-2 focus:ring-gray-300 focus:ring-offset-2 focus:ring-offset-white",
+          className,
+        )}
+        aria-label="글쓰기"
+        aria-expanded={isMenuOpen}
+      >
+        <Pen size={20} className="stroke-2" />
+      </button>
+
+      {/* 팝오버 메뉴 */}
+      {isMenuOpen && (
+        <div
+          ref={menuRef}
+          className={cn(
+            "absolute bottom-36 right-4 z-40 rounded-2xl bg-[#F2F4F6] text-gray-800 shadow-md border border-gray-200",
+            "animate-in fade-in-0 zoom-in-95 duration-150 ease-out",
+          )}
+          role="menu"
+        >
+          {menuItems.map((item, index) => (
+            <button
+              key={item.href}
+              onClick={() => handleMenuItemClick(item.href)}
+              className={cn(
+                "block w-full text-right px-4 py-3 min-h-[44px]",
+                "text-sm font-normal text-[#374151]",
+                "hover:bg-white hover:font-medium focus:bg-white focus:font-medium",
+                "transition-all duration-200",
+                "focus:outline-none",
+                index === 0 ? "rounded-t-2xl" : "",
+                index === menuItems.length - 1 ? "rounded-b-2xl" : "",
+              )}
+              role="menuitem"
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
       )}
-      aria-label={ariaLabel}
-    >
-      <Pen size={20} className="stroke-2" />
-    </button>
+    </>
   );
 }

--- a/components/ui/FloatingActionButton.tsx
+++ b/components/ui/FloatingActionButton.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { Pen } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { cn } from "@/utils/cn";
+
+interface FloatingActionButtonProps {
+  onClick?: () => void;
+  href?: string;
+  className?: string;
+  "aria-label"?: string;
+}
+
+export function FloatingActionButton({
+  onClick,
+  href = "/community/groups/create",
+  className,
+  "aria-label": ariaLabel = "글쓰기",
+}: FloatingActionButtonProps) {
+  const router = useRouter();
+
+  const handleClick = () => {
+    if (onClick) {
+      onClick();
+    } else if (href) {
+      router.push(href);
+    }
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      className={cn(
+        "absolute bottom-20 right-4 z-30",
+        "flex items-center justify-center w-14 h-14",
+        "bg-[#2ECC71] hover:bg-[#27AE60] active:bg-[#229954]",
+        "text-white rounded-full shadow-lg hover:shadow-xl",
+        "transition-all duration-200 ease-out",
+        "transform hover:scale-105 active:scale-95",
+        "focus:outline-none focus:ring-2 focus:ring-[#2ECC71] focus:ring-offset-2 focus:ring-offset-white",
+        className,
+      )}
+      aria-label={ariaLabel}
+    >
+      <Pen size={20} className="stroke-2" />
+    </button>
+  );
+}

--- a/components/ui/NavigationBar.tsx
+++ b/components/ui/NavigationBar.tsx
@@ -23,7 +23,7 @@ const navigationItems: NavigationItem[] = [
     id: "community",
     label: "커뮤니티",
     icon: "/icons/people.svg",
-    href: "/community",
+    href: "/community/groups",
   },
 ];
 

--- a/components/ui/PostCard.tsx
+++ b/components/ui/PostCard.tsx
@@ -1,51 +1,22 @@
 "use client";
 
-import { useState } from "react";
-import { Eye, MessageCircle, Heart, MoreVertical } from "lucide-react";
+import { Eye, MessageCircle, Heart, Users } from "lucide-react";
 import { cn } from "@/utils/cn";
 import { Post } from "@/types/community";
 
 interface PostCardProps {
   post: Post;
   onClick?: (post: Post) => void;
-  onMenuAction?: (action: "create_group" | "create_post", post: Post) => void;
   className?: string;
 }
 
-export function PostCard({
-  post,
-  onClick,
-  onMenuAction,
-  className,
-}: PostCardProps) {
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-
-  const handleCardClick = (e: React.MouseEvent) => {
-    if (e.target instanceof Element && e.target.closest("[data-menu]")) {
-      return;
-    }
+export function PostCard({ post, onClick, className }: PostCardProps) {
+  const handleCardClick = () => {
     onClick?.(post);
   };
 
-  const handleMenuClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    setIsMenuOpen(!isMenuOpen);
-  };
-
-  const handleMenuAction = (action: "create_group" | "create_post") => {
-    setIsMenuOpen(false);
-    onMenuAction?.(action, post);
-  };
-
-  const getBadgeStyles = (tone: Post["badge"]["tone"]) => {
-    switch (tone) {
-      case "success":
-        return "bg-[#2ECC71]/10 text-[#2ECC71]";
-      case "secondary":
-        return "bg-blue-50 text-blue-600";
-      default:
-        return "bg-gray-100 text-gray-600";
-    }
+  const getBadgeStyles = () => {
+    return "bg-[#F2F4F6] text-[#374151] hover:bg-[#E5E7EB]";
   };
 
   const getAuthorInitial = (name: string) => {
@@ -78,52 +49,26 @@ export function PostCard({
           <span>{post.region}</span>
         </div>
 
-        <div className="flex items-center gap-2">
-          {post.badge && (
-            <span
-              className={cn(
-                "px-2 py-1 text-xs font-medium rounded-full",
-                getBadgeStyles(post.badge.tone),
-              )}
-            >
-              {post.badge.label}
-            </span>
+        <div className="flex items-center gap-3">
+          {/* 모집 인원 (일반 제외 모든 카테고리) */}
+          {post.participants && (
+            <div className="flex items-center gap-1">
+              <Users size={12} className="text-gray-500" />
+              <span className="text-xs text-gray-600">
+                {post.participants.current}/{post.participants.max}
+              </span>
+            </div>
           )}
 
-          {/* 메뉴 버튼 */}
-          <div className="relative" data-menu>
-            <button
-              onClick={handleMenuClick}
-              className="flex items-center justify-center w-6 h-6 rounded-full hover:bg-gray-100 transition-colors"
-              aria-label="게시글 메뉴"
-              aria-expanded={isMenuOpen}
-            >
-              <MoreVertical size={16} className="text-gray-400" />
-            </button>
-
-            {isMenuOpen && (
-              <>
-                <div
-                  className="fixed inset-0 z-10"
-                  onClick={() => setIsMenuOpen(false)}
-                />
-                <div className="absolute right-0 top-full mt-1 bg-white border border-gray-200 rounded-lg shadow-lg py-1 z-20 min-w-[140px]">
-                  <button
-                    onClick={() => handleMenuAction("create_group")}
-                    className="w-full px-3 py-2 text-sm text-left text-gray-700 hover:bg-gray-50 transition-colors"
-                  >
-                    모임 개설
-                  </button>
-                  <button
-                    onClick={() => handleMenuAction("create_post")}
-                    className="w-full px-3 py-2 text-sm text-left text-gray-700 hover:bg-gray-50 transition-colors"
-                  >
-                    일반 게시글
-                  </button>
-                </div>
-              </>
+          {/* 카테고리 배지 */}
+          <span
+            className={cn(
+              "px-3 py-1 text-xs font-medium rounded-lg transition-colors duration-200",
+              getBadgeStyles(),
             )}
-          </div>
+          >
+            {post.category}
+          </span>
         </div>
       </div>
 

--- a/components/ui/PostCard.tsx
+++ b/components/ui/PostCard.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useState } from "react";
+import { Eye, MessageCircle, Heart, MoreVertical } from "lucide-react";
+import { cn } from "@/utils/cn";
+import { Post } from "@/types/community";
+
+interface PostCardProps {
+  post: Post;
+  onClick?: (post: Post) => void;
+  onMenuAction?: (action: "create_group" | "create_post", post: Post) => void;
+  className?: string;
+}
+
+export function PostCard({
+  post,
+  onClick,
+  onMenuAction,
+  className,
+}: PostCardProps) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  const handleCardClick = (e: React.MouseEvent) => {
+    if (e.target instanceof Element && e.target.closest("[data-menu]")) {
+      return;
+    }
+    onClick?.(post);
+  };
+
+  const handleMenuClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setIsMenuOpen(!isMenuOpen);
+  };
+
+  const handleMenuAction = (action: "create_group" | "create_post") => {
+    setIsMenuOpen(false);
+    onMenuAction?.(action, post);
+  };
+
+  const getBadgeStyles = (tone: Post["badge"]["tone"]) => {
+    switch (tone) {
+      case "success":
+        return "bg-[#2ECC71]/10 text-[#2ECC71]";
+      case "secondary":
+        return "bg-blue-50 text-blue-600";
+      default:
+        return "bg-gray-100 text-gray-600";
+    }
+  };
+
+  const getAuthorInitial = (name: string) => {
+    return name.charAt(0);
+  };
+
+  return (
+    <article
+      className={cn(
+        "bg-white rounded-2xl shadow-sm border border-gray-100 p-4 cursor-pointer transition-all duration-200",
+        "hover:shadow-md hover:-translate-y-0.5 active:scale-[0.98]",
+        className,
+      )}
+      onClick={handleCardClick}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          handleCardClick(e as React.MouseEvent);
+        }
+      }}
+      aria-label={`게시글: ${post.title}`}
+    >
+      {/* 상단 메타 라인 */}
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-1 text-sm text-gray-500">
+          <span>{post.createdAgo}</span>
+          <span>·</span>
+          <span>{post.region}</span>
+        </div>
+
+        <div className="flex items-center gap-2">
+          {post.badge && (
+            <span
+              className={cn(
+                "px-2 py-1 text-xs font-medium rounded-full",
+                getBadgeStyles(post.badge.tone),
+              )}
+            >
+              {post.badge.label}
+            </span>
+          )}
+
+          {/* 메뉴 버튼 */}
+          <div className="relative" data-menu>
+            <button
+              onClick={handleMenuClick}
+              className="flex items-center justify-center w-6 h-6 rounded-full hover:bg-gray-100 transition-colors"
+              aria-label="게시글 메뉴"
+              aria-expanded={isMenuOpen}
+            >
+              <MoreVertical size={16} className="text-gray-400" />
+            </button>
+
+            {isMenuOpen && (
+              <>
+                <div
+                  className="fixed inset-0 z-10"
+                  onClick={() => setIsMenuOpen(false)}
+                />
+                <div className="absolute right-0 top-full mt-1 bg-white border border-gray-200 rounded-lg shadow-lg py-1 z-20 min-w-[140px]">
+                  <button
+                    onClick={() => handleMenuAction("create_group")}
+                    className="w-full px-3 py-2 text-sm text-left text-gray-700 hover:bg-gray-50 transition-colors"
+                  >
+                    모임 개설
+                  </button>
+                  <button
+                    onClick={() => handleMenuAction("create_post")}
+                    className="w-full px-3 py-2 text-sm text-left text-gray-700 hover:bg-gray-50 transition-colors"
+                  >
+                    일반 게시글
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* 제목 */}
+      <h3 className="text-base font-semibold text-gray-900 leading-snug mb-2 line-clamp-2">
+        {post.title}
+      </h3>
+
+      {/* 본문 프리뷰 */}
+      <p className="text-sm text-gray-600 leading-relaxed mb-4 line-clamp-2">
+        {post.excerpt}
+      </p>
+
+      {/* 하단 라인 */}
+      <div className="flex items-center justify-between">
+        {/* 작성자 */}
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-gray-500">by</span>
+          <div className="flex items-center justify-center w-6 h-6 bg-gray-100 rounded-full text-xs font-medium text-gray-600">
+            {post.author.avatarUrl ? (
+              <img
+                src={post.author.avatarUrl}
+                alt={post.author.name}
+                className="w-full h-full rounded-full object-cover"
+              />
+            ) : (
+              getAuthorInitial(post.author.name)
+            )}
+          </div>
+          <span className="text-sm text-gray-500">{post.author.name}</span>
+        </div>
+
+        {/* 지표 아이콘 */}
+        <div className="flex items-center gap-4">
+          <div className="flex items-center gap-1">
+            <Eye size={14} className="text-gray-400" />
+            <span className="text-xs text-gray-500">{post.stats.views}</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <MessageCircle size={14} className="text-gray-400" />
+            <span className="text-xs text-gray-500">{post.stats.comments}</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <Heart size={14} className="text-gray-400" />
+            <span className="text-xs text-gray-500">{post.stats.likes}</span>
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/data/mockPosts.ts
+++ b/data/mockPosts.ts
@@ -5,7 +5,8 @@ export const mockPosts: Post[] = [
     id: "1",
     region: "신림동",
     createdAgo: "2일전",
-    badge: { label: "소분 모임", tone: "success" },
+    category: "소분 모임",
+    participants: { current: 9, max: 12 },
     title: "안전한 등하굣길 함께 만들어요 - 신림초등학교 학부모 모임",
     excerpt:
       "우리 아이들의 안전한 등하굣길을 위해 학부모님들과 함께 순번제로 교통안전지도를 하려고 합니다. 관심 있는 분들 많이 참여해주세요!",
@@ -16,7 +17,8 @@ export const mockPosts: Post[] = [
     id: "2",
     region: "관악구",
     createdAgo: "4시간전",
-    badge: { label: "소분 모임", tone: "success" },
+    category: "소분 모임",
+    participants: { current: 12, max: 15 },
     title: "낙성대 공원 산책모임 - 매주 화요일 저녁 7시",
     excerpt:
       "건강한 산책을 통해 이웃과 소통하며 동네 안전도 함께 지켜요. 누구나 부담 없이 참여 가능합니다.",
@@ -27,7 +29,8 @@ export const mockPosts: Post[] = [
     id: "3",
     region: "봉천동",
     createdAgo: "1일전",
-    badge: { label: "안전 수리", tone: "secondary" },
+    category: "안전 수리",
+    participants: { current: 18, max: 25 },
     title: "CCTV 설치 요청 - 봉천로 골목길",
     excerpt:
       "최근 봉천로 뒷골목에서 불안한 일들이 자주 발생하고 있어 CCTV 설치가 필요합니다. 구청에 공식 요청을 위해 주민 의견을 모으고 있습니다.",
@@ -38,7 +41,8 @@ export const mockPosts: Post[] = [
     id: "4",
     region: "서림동",
     createdAgo: "5일전",
-    badge: { label: "소분 모임", tone: "success" },
+    category: "소분 모임",
+    participants: { current: 6, max: 15 },
     title: "여성 안전귀가 동행 서비스 - 야간 시간대 운영",
     excerpt:
       "늦은 시간 혼자 귀가하기 불안한 여성분들을 위한 동행 서비스를 운영하려고 합니다. 함께 참여해주실 분들을 모집합니다.",
@@ -49,7 +53,8 @@ export const mockPosts: Post[] = [
     id: "5",
     region: "신사동",
     createdAgo: "3일전",
-    badge: { label: "소분 모임", tone: "success" },
+    category: "소분 모임",
+    participants: { current: 7, max: 12 },
     title: "우리 동네 안전지킴이 - 자율방범대 모집",
     excerpt:
       "동네 순찰과 안전활동을 통해 범죄 예방에 기여하고 싶은 주민분들을 모집합니다. 매주 토요일 오후 2시 정기 모임 있습니다.",
@@ -60,7 +65,8 @@ export const mockPosts: Post[] = [
     id: "6",
     region: "대학동",
     createdAgo: "1주전",
-    badge: { label: "안전 수리", tone: "secondary" },
+    category: "안전 수리",
+    participants: { current: 5, max: 10 },
     title: "가로등 고장 신고 및 수리 요청",
     excerpt:
       "대학동 주택가 골목길 가로등 여러 개가 고장나서 밤에 너무 어둡습니다. 관련 기관에 신고 접수했는데 빠른 수리가 필요해요.",
@@ -71,7 +77,8 @@ export const mockPosts: Post[] = [
     id: "7",
     region: "신림동",
     createdAgo: "2주전",
-    badge: { label: "소분 모임", tone: "success" },
+    category: "소분 모임",
+    participants: { current: 4, max: 10 },
     title: "어린이 교통안전 캠페인 - 스쿨존 속도준수",
     excerpt:
       "신림초등학교 앞 스쿨존에서 과속하는 차량들이 많아 위험합니다. 학부모와 주민이 함께하는 교통안전 캠페인을 진행하려고 합니다.",
@@ -82,7 +89,8 @@ export const mockPosts: Post[] = [
     id: "8",
     region: "관악구",
     createdAgo: "6일전",
-    badge: { label: "소분 모임", tone: "success" },
+    category: "소분 모임",
+    participants: { current: 14, max: 18 },
     title: "여성 1인 가구 안전 네트워크 - 정기 모임",
     excerpt:
       "혼자 사는 여성분들의 안전과 소통을 위한 정기 모임을 운영하고 있습니다. 서로 안부를 확인하고 안전 정보를 공유해요.",
@@ -93,7 +101,8 @@ export const mockPosts: Post[] = [
     id: "9",
     region: "봉천동",
     createdAgo: "1일전",
-    badge: { label: "취미·기타", tone: "default" },
+    category: "취미·기타",
+    participants: { current: 11, max: 15 },
     title: "주차 문제 해결을 위한 주민 협의회",
     excerpt:
       "봉천동 주택가 불법주차로 인한 통행 불편과 안전사고 위험이 증가하고 있습니다. 주민들과 함께 해결방안을 논의하고자 합니다.",
@@ -104,12 +113,24 @@ export const mockPosts: Post[] = [
     id: "10",
     region: "관악구",
     createdAgo: "3시간전",
-    badge: { label: "소분 모임", tone: "success" },
+    category: "소분 모임",
+    participants: { current: 8, max: 20 },
     title: "청소년 안전 교육 프로그램 - 강사 및 자원봉사자 모집",
     excerpt:
       "지역 청소년들을 대상으로 한 종합 안전교육 프로그램을 운영합니다. 교육 강사와 자원봉사자분들의 참여를 기다립니다.",
     author: { name: "김교육" },
     stats: { views: 45, comments: 2, likes: 7 },
+  },
+  {
+    id: "11",
+    region: "서초동",
+    createdAgo: "5일전",
+    category: "일반",
+    title: "동네 소식 공유 - 새로운 편의점 오픈",
+    excerpt:
+      "우리 동네에 새로운 편의점이 오픈했습니다. 24시간 운영하며 생필품부터 간편식까지 다양하게 구비되어 있어요.",
+    author: { name: "이웃사랑" },
+    stats: { views: 45, comments: 3, likes: 8 },
   },
 ];
 

--- a/data/mockPosts.ts
+++ b/data/mockPosts.ts
@@ -1,0 +1,126 @@
+import { Post } from "@/types/community";
+
+export const mockPosts: Post[] = [
+  {
+    id: "1",
+    region: "신림동",
+    createdAgo: "2일전",
+    badge: { label: "소분 모임", tone: "success" },
+    title: "안전한 등하굣길 함께 만들어요 - 신림초등학교 학부모 모임",
+    excerpt:
+      "우리 아이들의 안전한 등하굣길을 위해 학부모님들과 함께 순번제로 교통안전지도를 하려고 합니다. 관심 있는 분들 많이 참여해주세요!",
+    author: { name: "김희진" },
+    stats: { views: 124, comments: 8, likes: 15 },
+  },
+  {
+    id: "2",
+    region: "관악구",
+    createdAgo: "4시간전",
+    badge: { label: "소분 모임", tone: "success" },
+    title: "낙성대 공원 산책모임 - 매주 화요일 저녁 7시",
+    excerpt:
+      "건강한 산책을 통해 이웃과 소통하며 동네 안전도 함께 지켜요. 누구나 부담 없이 참여 가능합니다.",
+    author: { name: "이영수" },
+    stats: { views: 67, comments: 3, likes: 8 },
+  },
+  {
+    id: "3",
+    region: "봉천동",
+    createdAgo: "1일전",
+    badge: { label: "안전 수리", tone: "secondary" },
+    title: "CCTV 설치 요청 - 봉천로 골목길",
+    excerpt:
+      "최근 봉천로 뒷골목에서 불안한 일들이 자주 발생하고 있어 CCTV 설치가 필요합니다. 구청에 공식 요청을 위해 주민 의견을 모으고 있습니다.",
+    author: { name: "박민수" },
+    stats: { views: 203, comments: 18, likes: 32 },
+  },
+  {
+    id: "4",
+    region: "서림동",
+    createdAgo: "5일전",
+    badge: { label: "소분 모임", tone: "success" },
+    title: "여성 안전귀가 동행 서비스 - 야간 시간대 운영",
+    excerpt:
+      "늦은 시간 혼자 귀가하기 불안한 여성분들을 위한 동행 서비스를 운영하려고 합니다. 함께 참여해주실 분들을 모집합니다.",
+    author: { name: "최유진" },
+    stats: { views: 156, comments: 12, likes: 24 },
+  },
+  {
+    id: "5",
+    region: "신사동",
+    createdAgo: "3일전",
+    badge: { label: "소분 모임", tone: "success" },
+    title: "우리 동네 안전지킴이 - 자율방범대 모집",
+    excerpt:
+      "동네 순찰과 안전활동을 통해 범죄 예방에 기여하고 싶은 주민분들을 모집합니다. 매주 토요일 오후 2시 정기 모임 있습니다.",
+    author: { name: "정호영" },
+    stats: { views: 98, comments: 7, likes: 19 },
+  },
+  {
+    id: "6",
+    region: "대학동",
+    createdAgo: "1주전",
+    badge: { label: "안전 수리", tone: "secondary" },
+    title: "가로등 고장 신고 및 수리 요청",
+    excerpt:
+      "대학동 주택가 골목길 가로등 여러 개가 고장나서 밤에 너무 어둡습니다. 관련 기관에 신고 접수했는데 빠른 수리가 필요해요.",
+    author: { name: "장미래" },
+    stats: { views: 89, comments: 5, likes: 13 },
+  },
+  {
+    id: "7",
+    region: "신림동",
+    createdAgo: "2주전",
+    badge: { label: "소분 모임", tone: "success" },
+    title: "어린이 교통안전 캠페인 - 스쿨존 속도준수",
+    excerpt:
+      "신림초등학교 앞 스쿨존에서 과속하는 차량들이 많아 위험합니다. 학부모와 주민이 함께하는 교통안전 캠페인을 진행하려고 합니다.",
+    author: { name: "윤세라" },
+    stats: { views: 176, comments: 14, likes: 28 },
+  },
+  {
+    id: "8",
+    region: "관악구",
+    createdAgo: "6일전",
+    badge: { label: "소분 모임", tone: "success" },
+    title: "여성 1인 가구 안전 네트워크 - 정기 모임",
+    excerpt:
+      "혼자 사는 여성분들의 안전과 소통을 위한 정기 모임을 운영하고 있습니다. 서로 안부를 확인하고 안전 정보를 공유해요.",
+    author: { name: "한소영" },
+    stats: { views: 134, comments: 9, likes: 21 },
+  },
+  {
+    id: "9",
+    region: "봉천동",
+    createdAgo: "1일전",
+    badge: { label: "취미·기타", tone: "default" },
+    title: "주차 문제 해결을 위한 주민 협의회",
+    excerpt:
+      "봉천동 주택가 불법주차로 인한 통행 불편과 안전사고 위험이 증가하고 있습니다. 주민들과 함께 해결방안을 논의하고자 합니다.",
+    author: { name: "조민호" },
+    stats: { views: 87, comments: 6, likes: 11 },
+  },
+  {
+    id: "10",
+    region: "관악구",
+    createdAgo: "3시간전",
+    badge: { label: "소분 모임", tone: "success" },
+    title: "청소년 안전 교육 프로그램 - 강사 및 자원봉사자 모집",
+    excerpt:
+      "지역 청소년들을 대상으로 한 종합 안전교육 프로그램을 운영합니다. 교육 강사와 자원봉사자분들의 참여를 기다립니다.",
+    author: { name: "김교육" },
+    stats: { views: 45, comments: 2, likes: 7 },
+  },
+];
+
+export const categoryTabs = [
+  { id: "all", label: "전체", key: "전체" as const },
+  { id: "safety", label: "안전 수리", key: "안전 수리" as const },
+  { id: "small_group", label: "소분 모임", key: "소분 모임" as const },
+  { id: "hobby", label: "취미·기타", key: "취미·기타" as const },
+];
+
+export const sortOptions = [
+  { value: "등록순" as const, label: "등록순" },
+  { value: "최신순" as const, label: "최신순" },
+];

--- a/data/mockPosts.ts
+++ b/data/mockPosts.ts
@@ -139,6 +139,7 @@ export const categoryTabs = [
   { id: "safety", label: "안전 수리", key: "안전 수리" as const },
   { id: "small_group", label: "소분 모임", key: "소분 모임" as const },
   { id: "hobby", label: "취미·기타", key: "취미·기타" as const },
+  { id: "general", label: "일반", key: "일반" as const },
 ];
 
 export const sortOptions = [

--- a/types/community.ts
+++ b/types/community.ts
@@ -2,7 +2,8 @@ export interface Post {
   id: string;
   region: string;
   createdAgo: string;
-  badge?: { label: string; tone: "default" | "success" | "secondary" };
+  category: "안전 수리" | "소분 모임" | "취미·기타" | "일반";
+  participants?: { current: number; max: number }; // 모집 인원 (소분 모임일 때만)
   title: string;
   excerpt: string;
   author: { name: string; avatarUrl?: string };

--- a/types/community.ts
+++ b/types/community.ts
@@ -13,7 +13,7 @@ export interface Post {
 export interface CategoryTab {
   id: string;
   label: string;
-  key: "전체" | "안전 수리" | "소분 모임" | "취미·기타";
+  key: "전체" | "안전 수리" | "소분 모임" | "취미·기타" | "일반";
 }
 
 export interface SortOption {

--- a/types/community.ts
+++ b/types/community.ts
@@ -1,0 +1,29 @@
+export interface Post {
+  id: string;
+  region: string;
+  createdAgo: string;
+  badge?: { label: string; tone: "default" | "success" | "secondary" };
+  title: string;
+  excerpt: string;
+  author: { name: string; avatarUrl?: string };
+  stats: { views: number; comments: number; likes: number };
+}
+
+export interface CategoryTab {
+  id: string;
+  label: string;
+  key: "전체" | "안전 수리" | "소분 모임" | "취미·기타";
+}
+
+export interface SortOption {
+  value: "등록순" | "최신순";
+  label: string;
+}
+
+export type PostState = "loading" | "loaded" | "empty" | "error";
+
+export interface CommunityFilters {
+  category: CategoryTab["key"];
+  isInterestOnly: boolean;
+  sortBy: SortOption["value"];
+}


### PR DESCRIPTION
## 📝 Summary

모바일 우선 커뮤니티 모임 리스트 페이지를 구현했습니다. iOS 스타일 디자인과 직관적인 사용자 터페이스를 적용하여 카테고리 필터링, 정렬, 관심글 기능을 포함한 리스트를 제공합니다.

## 🔄 Type of Change

<!-- 해당하는 항목에 체크해주세요 -->

- [x] `feat` - 새로운 기능 추가
- [ ] `fix` - 버그 수정
- [ ] `docs` - 문서 변경
- [ ] `style` - 코드 스타일 변경
- [ ] `refactor` - 코드 리팩토링
- [ ] `test` - 테스트 추가/수정
- [ ] `chore` - 빌드 과정 또는 보조 도구 변경
- [ ] `perf` - 성능 개선

## 📸 Screenshots
<img width="439" height="889" alt="스크린샷 2025-08-10 오전 10 24 20" src="https://github.com/user-attachments/assets/f152bf5f-099d-4865-9409-4a6ff2d5f4ca" />
<img width="439" height="878" alt="스크린샷 2025-08-10 오전 10 24 27" src="https://github.com/user-attachments/assets/c70bd839-ef62-4ed2-9b26-2edbaeff105b" />

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 💥 변경사항

- NavigationBar 컴포넌트의 커뮤니티 링크가 /community/groups로 직접 연결됩니다
- 새로운 라우트 /community/groups 추가
- FAB 클릭 시 /community/new-group, /community/new-post로 라우팅됩니다

## 📚 리뷰어를 위한 참고사항

주요 구현 기능

  - 카테고리 필터: 5개 탭 (전체, 안전 수리, 소분 모임, 취미·기타, 일반) + 가로 스크롤
  - 정렬 기능: 등록순/최신순 세그먼트 토글 방식, URL 쿼리 동기화
  - 관심글 필터: 하트 아이콘 토글 (좋아요 15개 이상 필터)
  - 모집 인원: Users 아이콘과 함께 현재/최대 인원 표시 (일반 카테고리 제외)
  - FAB 메뉴: 회색 배경의 팝오버 메뉴 (모임 개설/일반 게시글)

  파일 구조

  - /app/community/groups/page.tsx - 메인 페이지 컴포넌트
  - /components/ui/Community*.tsx - 재사용 가능한 UI 컴포넌트들
  - /types/community.ts - TypeScript 인터페이스 정의
  - /data/mockPosts.ts - 샘플 데이터 (11개 게시글)

## Related Issues
Closes #8 